### PR TITLE
pass down the timestamp when reporting a value

### DIFF
--- a/openkit/protocol/beacon.py
+++ b/openkit/protocol/beacon.py
@@ -239,9 +239,7 @@ class Beacon:
         }
         event_type = type_to_event_type[type(value)]
 
-        event_time, event_string = self.build_event(event_type, value_name, parent_action_id)
-        if timestamp is not None:
-            event_time = timestamp
+        event_time, event_string = self.build_event(event_type, value_name, parent_action_id, timestamp)
 
         if event_type == EventType.VALUE_STRING:
             value = truncate(value)


### PR DESCRIPTION
If the report_value function is given a timestamp, it should be passed down into the event building functions.